### PR TITLE
Disable baud rate

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-mtr-1
-  version: "24.9.21.1"
+  version: "24.12.7.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -402,6 +402,7 @@ select:
     ld2450_id: ld2450_radar
     baud_rate:
       name: "Baud rate"
+      disabled_by_default: true
     zone_type:
       name: "Zone Type"
 


### PR DESCRIPTION
Version: 24.12.7.1

Adds:

Fixes:
- Disables baud rate selection by default

Breaks:



Checks:
- [ ] Documentation Updated
- [ ] Build Number Incremented In YAML
