### PR TITLE
Lock framework

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -7,11 +7,10 @@ esp32:
   board: esp32-c3-devkitm-1
   framework:
     type: esp-idf
+    version: 4.4.8
+    platform_version: 5.4.0
 
 captive_portal:
-
-web_server:
-  port: 80
 
 api:
   services:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-mtr-1
-  version: "25.1.3.1"
+  version: "25.1.11.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:

--- a/Integrations/ESPHome/MTR-1.yaml
+++ b/Integrations/ESPHome/MTR-1.yaml
@@ -1,7 +1,7 @@
 #Define Project
 substitutions:
   name: apollo-mtr-1
-  version: "25.1.3.1"
+  version: "25.1.11.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esphome:

--- a/Integrations/ESPHome/MTR-1_BLE.yaml
+++ b/Integrations/ESPHome/MTR-1_BLE.yaml
@@ -39,10 +39,5 @@ esp32_ble_tracker:
     active: false
 
 packages:
-  remote_package:
-    url: https://github.com/ApolloAutomation/MTR-1/
-    ref: main
-    files:
-      - Integrations/ESPHome/Core.yaml
-    refresh: 0d
+  core: !include Core.yaml
 


### PR DESCRIPTION
Version: 25.1.11.1

Adds:

Fixes:
- Lock framework version to reduce firmware size for BLE

Breaks:



Checks:
- [x] Documentation Updated
- [x] Build Number Incremented In YAML
