### PR TITLE
Update MTR-1.yaml

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-mtr-1
-  version: "25.3.24.1"
+  version: "25.4.10.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:

--- a/Integrations/ESPHome/MTR-1.yaml
+++ b/Integrations/ESPHome/MTR-1.yaml
@@ -1,9 +1,3 @@
-#Define Project
-substitutions:
-  name: apollo-mtr-1
-  version: "25.2.20.1"
-  device_description: ${name} made by Apollo Automation - version ${version}.
-
 esphome:
   name: "${name}"
   friendly_name: Apollo MTR-1


### PR DESCRIPTION
This removes the substitutions lines from the MTR-1.yaml file because they are already in the Core.yaml file.

This will fix the issue of the version number showing an old static version instead of the current version number from Core.yaml

Version:



Adds:

Fixes:

Breaks:



Checks:
- [ ] Documentation Updated
- [ ] Build Number Incremented In YAML
