### PR TITLE
Add support for LD2450 to use the set presence timeout.

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -166,6 +166,18 @@ rtttl:
   output: buzzer
 
 binary_sensor:
+  - platform: ld2450
+    ld2450_id: ld2450_radar
+    has_target:
+      id: has_target_bs
+      name: Presence
+    has_moving_target:
+      id: has_moving_target_bs
+      name: Moving Target
+    has_still_target:
+      id: has_still_target_bs
+      name: Still Target
+
   - platform: status
     name: Online
     id: ink_ha_connected


### PR DESCRIPTION
Currently the yaml has a bug where the timeout for presence is ignored because we have lines in the yaml missing.

We will likely need to add this to the r-pro-1 yaml as well since it also uses the LD2450.

More info from keith at ESPHome here: https://github.com/esphome/issues/issues/7006#issuecomment-2998616097

<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version:

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?



## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [ ] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->


