### PR TITLE
Updates for 2025.8.0 ESPHome release

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-mtr-1
-  version: "25.8.6.1"
+  version: "25.8.12.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
@@ -82,7 +82,6 @@ uart:
 ld2450:
   id: ld2450_radar
   uart_id: uart_bus
-  throttle: 500ms
 
 number:
   - platform: ld2450
@@ -364,6 +363,12 @@ light:
           max_brightness: 100%
 
 button:
+  - platform: ld2450
+    ld2450_id: ld2450_radar
+    factory_reset:
+      name: "Factory Reset LD2450"
+      disabled_by_default: True
+  
   - platform: restart
     icon: mdi:power-cycle
     name: "ESP Reboot"

--- a/Integrations/ESPHome/MTR-1_Factory.yaml
+++ b/Integrations/ESPHome/MTR-1_Factory.yaml
@@ -3,14 +3,12 @@ esphome:
   friendly_name: Apollo MTR-1
   comment: Apollo MTR-1
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
 
   project:
     name: "ApolloAutomation.MTR-1"
     version: "${version}"
 
-  min_version: 2024.6.4
+  min_version: 2025.8.0
   on_boot:
     priority: -10
     then:


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version:

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

This PR updates the configuration for the 2025.8.0 release of ESPHome, specifically by removing the `throttle` configuration variable for the LD2450, as it has been removed.

In addition:

- Removes redundant platformio configuration which is unnecessary with IDF 5+.
- Adds factory reset `button` for LD2450, useful for troubleshooting.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [ ] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->