### PR TITLE
web server upgrade to version 3, framework updated to newest suggested version, buzzer action replaces old buzzer service call, min version changed.

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -24,7 +24,7 @@ api:
         - rtttl.play:
             rtttl: !lambda "return song_str;"
 
-    #Co2 Calibration Service
+#Co2 Calibration Action
     - action: calibrate_co2_value
       variables:
         co2_ppm: float

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,18 +1,21 @@
 substitutions:
   name: apollo-mtr-1
-  version: "25.9.19.1"
+  version: "26.1.27.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
-  board: esp32-c3-devkitm-1
-  framework:
-    type: esp-idf
+  variant: esp32c3
+  flash_size: 4MB
 
 captive_portal:
 
+web_server:
+  port: 80
+  version: 3
+
 api:
-  services:
-    - service: play_buzzer
+  actions:
+    - action: play_buzzer
       variables:
         song_str: string
       then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -6,6 +6,8 @@ substitutions:
 esp32:
   variant: esp32c3
   flash_size: 4MB
+  framework:
+    type: esp-idf
 
 captive_portal:
 

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -25,7 +25,7 @@ api:
             rtttl: !lambda "return song_str;"
 
     #Co2 Calibration Service
-    - service: calibrate_co2_value
+    - action: calibrate_co2_value
       variables:
         co2_ppm: float
       then:

--- a/Integrations/ESPHome/MTR-1.yaml
+++ b/Integrations/ESPHome/MTR-1.yaml
@@ -3,14 +3,12 @@ esphome:
   friendly_name: Apollo MTR-1
   comment: Apollo MTR-1
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
 
   project:
     name: "ApolloAutomation.MTR-1"
     version: "${version}"
 
-  min_version: 2024.6.0
+  min_version: 2025.8.0
   on_boot:
     priority: -10
     then:
@@ -35,8 +33,5 @@ wifi:
   ap:
     ssid: "Apollo MTR1 Hotspot"
     
-web_server:
-  port: 80
-
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/MTR-1_BLE.yaml
+++ b/Integrations/ESPHome/MTR-1_BLE.yaml
@@ -3,14 +3,12 @@ esphome:
   friendly_name: Apollo MTR-1
   comment: Apollo MTR-1
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
 
   project:
     name: "ApolloAutomation.MTR-1"
     version: "${version}"
 
-  min_version: 2024.6.4
+  min_version: 2025.8.0
   on_boot:
     priority: -10
     then:

--- a/Integrations/ESPHome/MTR-1_Factory.yaml
+++ b/Integrations/ESPHome/MTR-1_Factory.yaml
@@ -28,11 +28,6 @@ esp32_improv:
   authorizer: none
 
 wifi:
-  on_connect:
-    - delay: 5s  
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
   ap:
     ssid: "Apollo MTR1 Hotspot"
 


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.1.27.1

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

web server upgrade to version 3, framework updated to newest suggested version, buzzer action replaces old buzzer service call, min version changed.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [x] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release version bumped to 26.1.27.1
  * Raised minimum ESPHome requirement to 2025.8.0
  * Updated ESP32 variant and flash size

* **New Features**
  * Added web server interface to core device configuration

* **Behavior Changes**
  * Service-style controls migrated to an action-based API (e.g., play_buzzer, calibrate_co2_value)
  * Removed legacy build option and removed web server from some device profiles
  * Removed automatic BLE toggling and startup Wi‑Fi delay on factory device configs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->