### PR TITLE
Add boot improvements and version sensors

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -19,7 +19,12 @@ api:
   on_client_connected:
     then:
       - delay: 1s  # Let connection stabilize before showing status
-      - script.execute: statusCheck
+      - if:
+          condition:
+            - lambda: 'return !id(first_boot_done);'
+          then:
+            - lambda: 'id(first_boot_done) = true;'
+            - script.execute: statusCheck
   actions:
     - action: play_buzzer
       variables:
@@ -218,6 +223,10 @@ binary_sensor:
               id(testCycleCount) = 0;
               id(runTest) = true;
               id(testScript).execute();
+            }
+            else {
+              // Short press (<1s) - run status check
+              id(statusCheck).execute();
             }
 
 sensor:
@@ -453,44 +462,37 @@ script:
     then:
       - if:
           condition:
-            - lambda: 'return id(first_boot_done);'
+            - lambda: 'return id(ink_ha_connected).state;'
           then:
-            - logger.log: "Apollo Automation: Skipping status check (not first boot)"
+            - logger.log: "Apollo Automation: Connected To HA"
+            - light.turn_on:
+                id: rgb_light
+                brightness: 100%
+                red: 0%
+                green: 0%
+                blue: 100%
           else:
-            - lambda: 'id(first_boot_done) = true;'
             - if:
                 condition:
-                  - lambda: 'return id(ink_ha_connected).state;'
+                  - wifi.connected
                 then:
-                  - logger.log: "Apollo Automation: Connected To HA"
+                  - logger.log: "Apollo Automation: Connected To Wifi"
                   - light.turn_on:
                       id: rgb_light
                       brightness: 100%
                       red: 0%
-                      green: 0%
-                      blue: 100%
+                      green: 100%
+                      blue: 0%
                 else:
-                  - if:
-                      condition:
-                        - wifi.connected
-                      then:
-                        - logger.log: "Apollo Automation: Connected To Wifi"
-                        - light.turn_on:
-                            id: rgb_light
-                            brightness: 100%
-                            red: 0%
-                            green: 100%
-                            blue: 0%
-                      else:
-                        - logger.log: "Apollo Automation: Not Connected To Wifi"
-                        - light.turn_on:
-                            id: rgb_light
-                            brightness: 100%
-                            red: 100%
-                            green: 100%
-                            blue: 0%
-            - delay: 5s
-            - light.turn_off: rgb_light
+                  - logger.log: "Apollo Automation: Not Connected To Wifi"
+                  - light.turn_on:
+                      id: rgb_light
+                      brightness: 100%
+                      red: 100%
+                      green: 100%
+                      blue: 0%
+      - delay: 5s
+      - light.turn_off: rgb_light
 
   - id: testScript      
     then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -18,6 +18,7 @@ web_server:
 api:
   on_client_connected:
     then:
+      - delay: 1s  # Let connection stabilize before showing status
       - script.execute: statusCheck
   actions:
     - action: play_buzzer
@@ -448,7 +449,7 @@ text_sensor:
 
 script:
   - id: statusCheck
-    mode: restart
+    mode: single  # First call runs to completion, subsequent calls ignored
     then:
       - if:
           condition:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -427,8 +427,56 @@ text_sensor:
       direction:
         name: "Target-3 Direction"
 
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+
+  - platform: template
+    name: "Firmware Version"
+    id: apollo_firmware_version
+    update_interval: 5s
+    lambda: |-
+      return {"${version}"};
+    entity_category: "diagnostic"
+
 
 script:
+  - id: statusCheck
+    then:
+      - if:
+          condition:
+            - lambda: 'return id(ink_ha_connected).state;'
+          then:
+            - logger.log: "Apollo Automation: Connected To HA"
+            - light.turn_on:
+                id: rgb_light
+                brightness: 100%
+                red: 0%
+                green: 0%
+                blue: 100%
+          else:
+            - if:
+                condition:
+                  - wifi.connected
+                then:
+                  - logger.log: "Apollo Automation: Connected To Wifi"
+                  - light.turn_on:
+                      id: rgb_light
+                      brightness: 100%
+                      red: 0%
+                      green: 100%
+                      blue: 0%
+                else:
+                  - logger.log: "Apollo Automation: Not Connected To Wifi"
+                  - light.turn_on:
+                      id: rgb_light
+                      brightness: 100%
+                      red: 100%
+                      green: 100%
+                      blue: 0%
+      - delay: 5s
+      - light.turn_off: rgb_light
+
   - id: testScript      
     then:
       if: 

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -444,6 +444,7 @@ text_sensor:
 
 script:
   - id: statusCheck
+    mode: restart
     then:
       - if:
           condition:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -16,6 +16,9 @@ web_server:
   version: 3
 
 api:
+  on_connect:
+    then:
+      - script.execute: statusCheck
   actions:
     - action: play_buzzer
       variables:
@@ -434,7 +437,6 @@ text_sensor:
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version
-    update_interval: 5s
     lambda: |-
       return {"${version}"};
     entity_category: "diagnostic"

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -16,7 +16,7 @@ web_server:
   version: 3
 
 api:
-  on_connect:
+  on_client_connected:
     then:
       - script.execute: statusCheck
   actions:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -65,6 +65,10 @@ globals:
     restore_value: no
     type: bool
     initial_value: "false"
+  - id: first_boot_done
+    restore_value: no
+    type: bool
+    initial_value: "false"
 
 i2c:
   sda: GPIO1
@@ -448,37 +452,44 @@ script:
     then:
       - if:
           condition:
-            - lambda: 'return id(ink_ha_connected).state;'
+            - lambda: 'return id(first_boot_done);'
           then:
-            - logger.log: "Apollo Automation: Connected To HA"
-            - light.turn_on:
-                id: rgb_light
-                brightness: 100%
-                red: 0%
-                green: 0%
-                blue: 100%
+            - logger.log: "Apollo Automation: Skipping status check (not first boot)"
           else:
+            - lambda: 'id(first_boot_done) = true;'
             - if:
                 condition:
-                  - wifi.connected
+                  - lambda: 'return id(ink_ha_connected).state;'
                 then:
-                  - logger.log: "Apollo Automation: Connected To Wifi"
+                  - logger.log: "Apollo Automation: Connected To HA"
                   - light.turn_on:
                       id: rgb_light
                       brightness: 100%
                       red: 0%
-                      green: 100%
-                      blue: 0%
+                      green: 0%
+                      blue: 100%
                 else:
-                  - logger.log: "Apollo Automation: Not Connected To Wifi"
-                  - light.turn_on:
-                      id: rgb_light
-                      brightness: 100%
-                      red: 100%
-                      green: 100%
-                      blue: 0%
-      - delay: 5s
-      - light.turn_off: rgb_light
+                  - if:
+                      condition:
+                        - wifi.connected
+                      then:
+                        - logger.log: "Apollo Automation: Connected To Wifi"
+                        - light.turn_on:
+                            id: rgb_light
+                            brightness: 100%
+                            red: 0%
+                            green: 100%
+                            blue: 0%
+                      else:
+                        - logger.log: "Apollo Automation: Not Connected To Wifi"
+                        - light.turn_on:
+                            id: rgb_light
+                            brightness: 100%
+                            red: 100%
+                            green: 100%
+                            blue: 0%
+            - delay: 5s
+            - light.turn_off: rgb_light
 
   - id: testScript      
     then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -21,7 +21,7 @@ api:
       - delay: 1s  # Let connection stabilize before showing status
       - if:
           condition:
-            - lambda: 'return !id(first_boot_done);'
+            - lambda: 'return !id(first_boot_done) && id(boot_status_enabled);'
           then:
             - lambda: 'id(first_boot_done) = true;'
             - script.execute: statusCheck
@@ -75,6 +75,10 @@ globals:
     restore_value: no
     type: bool
     initial_value: "false"
+  - id: boot_status_enabled
+    restore_value: yes
+    type: bool
+    initial_value: "true"
 
 i2c:
   sda: GPIO1
@@ -219,14 +223,8 @@ binary_sensor:
             if (millis() - id(button_press_timestamp) >= 8000) {
               id(factory_reset_switch).turn_on();
             }
-            else if (millis() - id(button_press_timestamp) >= 1000) {
-              id(testCycleCount) = 0;
-              id(runTest) = true;
-              id(testScript).execute();
-            }
-            else {
-              // Short press (<1s) - run status check
-              id(statusCheck).execute();
+            else if (millis() - id(button_press_timestamp) >= 2000) {
+              id(diagnosticCheck).execute();
             }
 
 sensor:
@@ -412,6 +410,18 @@ switch:
   - platform: factory_reset
     id: factory_reset_switch
     internal: true
+  - platform: template
+    name: "Boot Status LED"
+    id: boot_status_led_switch
+    icon: mdi:led-on
+    entity_category: "config"
+    restore_mode: RESTORE_DEFAULT_ON
+    optimistic: true
+    lambda: 'return id(boot_status_enabled);'
+    turn_on_action:
+      - lambda: 'id(boot_status_enabled) = true;'
+    turn_off_action:
+      - lambda: 'id(boot_status_enabled) = false;'
   - platform: ld2450
     ld2450_id: ld2450_radar
     bluetooth:
@@ -493,6 +503,17 @@ script:
                       blue: 0%
       - delay: 5s
       - light.turn_off: rgb_light
+
+  - id: diagnosticCheck
+    mode: single
+    then:
+      - script.execute: statusCheck
+      - script.wait: statusCheck
+      - delay: 3s
+      - lambda: |-
+          id(testCycleCount) = 0;
+          id(runTest) = true;
+      - script.execute: testScript
 
   - id: testScript      
     then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -432,7 +432,7 @@ text_sensor:
     hide_timestamp: true
 
   - platform: template
-    name: "Firmware Version"
+    name: "Apollo Firmware Version"
     id: apollo_firmware_version
     update_interval: 5s
     lambda: |-

--- a/Integrations/ESPHome/MTR-1.yaml
+++ b/Integrations/ESPHome/MTR-1.yaml
@@ -37,7 +37,7 @@ wifi:
       - delay: 10s  # Give HA time to connect first, then fall back to WiFi-only status
       - if:
           condition:
-            - lambda: 'return !id(first_boot_done);'
+            - lambda: 'return !id(first_boot_done) && id(boot_status_enabled);'
           then:
             - lambda: 'id(first_boot_done) = true;'
             - script.execute: statusCheck

--- a/Integrations/ESPHome/MTR-1.yaml
+++ b/Integrations/ESPHome/MTR-1.yaml
@@ -34,6 +34,7 @@ wifi:
     ssid: "Apollo MTR1 Hotspot"
   on_connect:
     then:
+      - delay: 10s  # Give HA time to connect first, then fall back to WiFi-only status
       - script.execute: statusCheck
     
 packages:

--- a/Integrations/ESPHome/MTR-1.yaml
+++ b/Integrations/ESPHome/MTR-1.yaml
@@ -12,7 +12,6 @@ esphome:
   on_boot:
     priority: 600
     then:
-      - script.execute: statusCheck
       - if:
           condition:
             - lambda: "return id(runTest);"
@@ -33,6 +32,9 @@ wifi:
   power_save_mode: none
   ap:
     ssid: "Apollo MTR1 Hotspot"
+  on_connect:
+    then:
+      - script.execute: statusCheck
     
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/MTR-1.yaml
+++ b/Integrations/ESPHome/MTR-1.yaml
@@ -35,7 +35,12 @@ wifi:
   on_connect:
     then:
       - delay: 10s  # Give HA time to connect first, then fall back to WiFi-only status
-      - script.execute: statusCheck
+      - if:
+          condition:
+            - lambda: 'return !id(first_boot_done);'
+          then:
+            - lambda: 'id(first_boot_done) = true;'
+            - script.execute: statusCheck
     
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/MTR-1.yaml
+++ b/Integrations/ESPHome/MTR-1.yaml
@@ -10,7 +10,7 @@ esphome:
 
   min_version: 2025.8.0
   on_boot:
-    priority: -10
+    priority: 600
     then:
       - script.execute: statusCheck
       - if:

--- a/Integrations/ESPHome/MTR-1.yaml
+++ b/Integrations/ESPHome/MTR-1.yaml
@@ -12,6 +12,7 @@ esphome:
   on_boot:
     priority: -10
     then:
+      - script.execute: statusCheck
       - if:
           condition:
             - lambda: "return id(runTest);"

--- a/Integrations/ESPHome/MTR-1_BLE.yaml
+++ b/Integrations/ESPHome/MTR-1_BLE.yaml
@@ -12,7 +12,6 @@ esphome:
   on_boot:
     priority: 600
     then:
-      - script.execute: statusCheck
       - if:
           condition:
             - lambda: "return id(runTest);"
@@ -32,6 +31,9 @@ ota:
 wifi:
   ap:
     ssid: "Apollo MTR1 Hotspot"
+  on_connect:
+    then:
+      - script.execute: statusCheck
 
 bluetooth_proxy:
   active: true

--- a/Integrations/ESPHome/MTR-1_BLE.yaml
+++ b/Integrations/ESPHome/MTR-1_BLE.yaml
@@ -36,7 +36,7 @@ wifi:
       - delay: 10s  # Give HA time to connect first, then fall back to WiFi-only status
       - if:
           condition:
-            - lambda: 'return !id(first_boot_done);'
+            - lambda: 'return !id(first_boot_done) && id(boot_status_enabled);'
           then:
             - lambda: 'id(first_boot_done) = true;'
             - script.execute: statusCheck

--- a/Integrations/ESPHome/MTR-1_BLE.yaml
+++ b/Integrations/ESPHome/MTR-1_BLE.yaml
@@ -34,7 +34,12 @@ wifi:
   on_connect:
     then:
       - delay: 10s  # Give HA time to connect first, then fall back to WiFi-only status
-      - script.execute: statusCheck
+      - if:
+          condition:
+            - lambda: 'return !id(first_boot_done);'
+          then:
+            - lambda: 'id(first_boot_done) = true;'
+            - script.execute: statusCheck
 
 bluetooth_proxy:
   active: true

--- a/Integrations/ESPHome/MTR-1_BLE.yaml
+++ b/Integrations/ESPHome/MTR-1_BLE.yaml
@@ -10,7 +10,7 @@ esphome:
 
   min_version: 2025.8.0
   on_boot:
-    priority: -10
+    priority: 600
     then:
       - script.execute: statusCheck
       - if:

--- a/Integrations/ESPHome/MTR-1_BLE.yaml
+++ b/Integrations/ESPHome/MTR-1_BLE.yaml
@@ -33,6 +33,7 @@ wifi:
     ssid: "Apollo MTR1 Hotspot"
   on_connect:
     then:
+      - delay: 10s  # Give HA time to connect first, then fall back to WiFi-only status
       - script.execute: statusCheck
 
 bluetooth_proxy:

--- a/Integrations/ESPHome/MTR-1_BLE.yaml
+++ b/Integrations/ESPHome/MTR-1_BLE.yaml
@@ -12,6 +12,7 @@ esphome:
   on_boot:
     priority: -10
     then:
+      - script.execute: statusCheck
       - if:
           condition:
             - lambda: "return id(runTest);"

--- a/Integrations/ESPHome/MTR-1_Factory.yaml
+++ b/Integrations/ESPHome/MTR-1_Factory.yaml
@@ -33,7 +33,12 @@ wifi:
   on_connect:
     then:
       - delay: 10s  # Give HA time to connect first, then fall back to WiFi-only status
-      - script.execute: statusCheck
+      - if:
+          condition:
+            - lambda: 'return !id(first_boot_done);'
+          then:
+            - lambda: 'id(first_boot_done) = true;'
+            - script.execute: statusCheck
 
 logger:
 

--- a/Integrations/ESPHome/MTR-1_Factory.yaml
+++ b/Integrations/ESPHome/MTR-1_Factory.yaml
@@ -10,7 +10,7 @@ esphome:
 
   min_version: 2025.8.0
   on_boot:
-    priority: -10
+    priority: 600
     then:
       - script.execute: statusCheck
       - if:

--- a/Integrations/ESPHome/MTR-1_Factory.yaml
+++ b/Integrations/ESPHome/MTR-1_Factory.yaml
@@ -35,7 +35,7 @@ wifi:
       - delay: 10s  # Give HA time to connect first, then fall back to WiFi-only status
       - if:
           condition:
-            - lambda: 'return !id(first_boot_done);'
+            - lambda: 'return !id(first_boot_done) && id(boot_status_enabled);'
           then:
             - lambda: 'id(first_boot_done) = true;'
             - script.execute: statusCheck

--- a/Integrations/ESPHome/MTR-1_Factory.yaml
+++ b/Integrations/ESPHome/MTR-1_Factory.yaml
@@ -12,7 +12,6 @@ esphome:
   on_boot:
     priority: 600
     then:
-      - script.execute: statusCheck
       - if:
           condition:
             - lambda: "return id(runTest);"
@@ -31,6 +30,9 @@ esp32_improv:
 wifi:
   ap:
     ssid: "Apollo MTR1 Hotspot"
+  on_connect:
+    then:
+      - script.execute: statusCheck
 
 logger:
 

--- a/Integrations/ESPHome/MTR-1_Factory.yaml
+++ b/Integrations/ESPHome/MTR-1_Factory.yaml
@@ -12,6 +12,7 @@ esphome:
   on_boot:
     priority: -10
     then:
+      - script.execute: statusCheck
       - if:
           condition:
             - lambda: "return id(runTest);"

--- a/Integrations/ESPHome/MTR-1_Factory.yaml
+++ b/Integrations/ESPHome/MTR-1_Factory.yaml
@@ -32,6 +32,7 @@ wifi:
     ssid: "Apollo MTR1 Hotspot"
   on_connect:
     then:
+      - delay: 10s  # Give HA time to connect first, then fall back to WiFi-only status
       - script.execute: statusCheck
 
 logger:


### PR DESCRIPTION
## Summary
Adds diagnostic text sensors and connection status indication during boot sequence.

## Changes
- **Text Sensors**: Added ESPHome Version and Apollo Firmware Version sensors for diagnostics
- **Connection Status**: Added statusCheck script matching BTN-1 implementation
  - Blue light (5s): Connected to Home Assistant
  - Green light (5s): Connected to WiFi only  
  - Yellow light (5s): Not connected
- **Boot Sequence**: Updated to show connection status before hardware test
- **Cleanup**: Removed redundant white startup blink

## Testing Status
Ready for local testing and validation on hardware.

## Files Modified
- Core.yaml - Added text sensors and statusCheck script
- MTR-1.yaml - Updated boot sequence
- MTR-1_BLE.yaml - Updated boot sequence
- MTR-1_Factory.yaml - Updated boot sequence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two text sensors added for ESPHome and device firmware versions.
  * New statusCheck and diagnosticCheck scripts to indicate connection state via RGB status and run diagnostic sequences; Boot Status LED switch added to control boot-status behavior.
  * Short button press now triggers a diagnostic check.

* **Chores**
  * Boot/connect sequencing adjusted so status checks run reliably on first boot and reconnects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->