### PR TITLE
Fix LD2450 buffer overflow during initialization

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -80,6 +80,7 @@ uart:
     mode:
       input: true
       pullup: true
+  rx_buffer_size: 1024
   baud_rate: 256000
   parity: NONE
   stop_bits: 1


### PR DESCRIPTION
## Summary
Adds `rx_buffer_size: 1024` to the uart_bus configuration to prevent buffer overflow during device initialization.

## Problem
The LD2450 sensor randomly stops detecting after several hours of operation. Root cause analysis (esphome/esphome#13956) revealed:
- Default 256-byte UART buffer overflows during boot
- ~750 bytes accumulate during 2-second dump_config() block
- Overflow corrupts initialization commands
- Sensor enters broken state causing detection failures

## Solution
Increase rx_buffer_size to 1024 bytes to accommodate data accumulation during boot sequence.

## Testing
- Compile and flash to MTR-1 device
- Verify LD2450 sensor initializes correctly
- Confirm detection remains stable over extended period (24+ hours)
- No factory resets should be required

Fixes esphome/esphome#13956

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded UART buffer capacity to improve serial communication handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->