### PR TITLE
Fix auto-assign workflow for forked PRs

### DIFF
--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -7,12 +7,14 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+    # Skip auto-assign for pull requests from forks due to GITHUB_TOKEN permission restrictions
+    if: github.event_name == 'issues' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       issues: write
       pull-requests: write
     steps:
     - name: 'Auto-assign issue'
-      uses: pozil/auto-assign-issue@v1
+      uses: pozil/auto-assign-issue@v2
       with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: TrevorSchirmer


### PR DESCRIPTION
## Summary
- Upgraded `pozil/auto-assign-issue` from v1 to v2
- Added conditional to skip auto-assign for forked PRs
- Prevents "Resource not accessible by integration" 403 error

## Problem
The auto-assign workflow was failing on forked PRs with a 403 error (see [failed run](https://github.com/ApolloAutomation/MTR-1/actions/runs/22000789061/job/63572594679?pr=77)).

GitHub Actions restricts `GITHUB_TOKEN` permissions for pull requests from forks as a security measure, even when permissions are explicitly granted in the workflow file.

## Solution
Added a conditional check:
```yaml
if: github.event_name == 'issues' || github.event.pull_request.head.repo.full_name == github.repository
```

This ensures the workflow:
- ✅ Runs for all issues
- ✅ Runs for PRs from the same repository
- ⏭️  Skips for PRs from forks (gracefully, without error)

## Test plan
- [ ] Verify auto-assign works for issues
- [ ] Verify auto-assign works for same-repo PRs
- [ ] Verify workflow skips cleanly for forked PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated auto-assignment workflow to use the latest action version with improved handling for pull requests from external contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->