### PR TITLE
[MTR-1] Add ESPHome Version and Apollo Firmware Version text sensors

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -426,6 +426,15 @@ text_sensor:
     target_3:
       direction:
         name: "Target-3 Direction"
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    lambda: |-
+      return {"${version}"};
+    entity_category: "diagnostic"
 
 
 script:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -435,6 +435,7 @@ text_sensor:
     id: apollo_firmware_version
     lambda: |-
       return {"${version}"};
+    update_interval: never
     entity_category: "diagnostic"
 
 

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -429,6 +429,7 @@ text_sensor:
   - platform: version
     name: "ESPHome Version"
     hide_timestamp: true
+    entity_category: "diagnostic"
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version


### PR DESCRIPTION
Version: 26.1.27.1

## What does this implement/fix?

Adds two diagnostic text sensors to `Core.yaml`:

- **ESPHome Version** — exposes the running ESPHome version via the `version` platform (timestamp hidden)
- **Apollo Firmware Version** — exposes the substitution variable `${version}` as a diagnostic entity via the `template` platform

These sensors make firmware and ESPHome version visible in Home Assistant for diagnostics and automation without requiring any other changes.

## Types of changes

- [x] New feature (thanks!)

## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added ESPHome Version sensor to display the current ESPHome version
* Added Apollo Firmware Version sensor to monitor the installed firmware version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->