### PR TITLE
[wifi_info] Add IP address text sensor

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -494,6 +494,11 @@ text_sensor:
       return {"${version}"};
     update_interval: never
     entity_category: "diagnostic"
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
+      id: wifi_ip
+      entity_category: "diagnostic"
 
 
 script:


### PR DESCRIPTION
## Summary
- Adds `wifi_info` IP address text sensor to Core.yaml
- Marked as diagnostic entity so it stays off the main HA device card
- Consistent with all other Apollo Automation device repos

## Test plan
- [ ] `esphome config` validates cleanly
- [ ] IP address appears in HA under diagnostic entities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a diagnostic Wi‑Fi information sensor that exposes the device IP address as a read‑only text metric labeled "IP Address".
  * This sensor appears in the device's diagnostic sensors list, providing a simple, visible way to see the current IP address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->