### PR TITLE
[MTR-1] Add ESPHome Version and Apollo Firmware Version text sensors

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -464,6 +464,17 @@ text_sensor:
     target_3:
       direction:
         name: "Target-3 Direction"
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+    entity_category: "diagnostic"
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    lambda: |-
+      return {"${version}"};
+    update_interval: never
+    entity_category: "diagnostic"
 
 
 script:


### PR DESCRIPTION
## What does this implement/fix?

Adds ESPHome version and Apollo firmware version as diagnostic text sensors, matching the pattern used across all other Apollo device repos.

Replaces PR #79 (which was opened from a fork and had label-check failures).

## Types of changes
- [x] New feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ESPHome Version diagnostic sensor - displays detailed information about your currently installed ESPHome version
  * Added Apollo Firmware Version diagnostic sensor - displays information about your Apollo firmware version

These new diagnostic sensors have been added to your ESPHome integration configuration for system version tracking and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->