### PR TITLE
Fix LTR390 interval lambda: handle NAN state, remove boot timing guard

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -433,10 +433,11 @@ interval:
       - lambda: |-
           uint32_t current_time = millis() / 1000;  // Convert to seconds
           uint32_t last_update = id(ltr390_last_update);
-          uint32_t interval = (uint32_t)id(ltr390_update_interval).state;
+          float configured_interval = id(ltr390_update_interval).state;
+          uint32_t interval = (configured_interval >= 1.0f) ? (uint32_t)configured_interval : 60u;
 
           // Immediate update on boot (when last_update is still 0)
-          if (last_update == 0 && current_time > 0) {
+          if (last_update == 0) {
             id(ltr_390).update();
             id(ltr390_last_update) = current_time;
             return;


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.3.2.1

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

Fixes two issues in the LTR390 interval lambda:

- **NAN cast**: `(uint32_t)id(ltr390_update_interval).state` is undefined behavior when the template number hasn't initialized yet (state is NAN). Replaced with a ternary that falls back to 60s when the value is not `>= 1.0f` — NAN comparisons return false so this handles both cases.
- **Boot timing guard**: `last_update == 0 && current_time > 0` prevented the immediate boot update from firing in the first second (`millis() / 1000 == 0`). Removed `current_time > 0` so the update fires on the first tick whenever `last_update == 0`.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->