### PR TITLE
Fix Apollo Firmware Version sensor showing unknown

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -493,7 +493,6 @@ text_sensor:
     id: apollo_firmware_version
     lambda: |-
       return {"${version}"};
-    update_interval: never
     entity_category: "diagnostic"
   - platform: wifi_info
     ip_address:


### PR DESCRIPTION
Version:

## What does this implement/fix?

Fixes Apollo Firmware Version text sensor showing "unknown" in Home Assistant.

- Removed `update_interval: never` so the lambda also fires periodically (every 60s) as a fallback

The root cause is that ESPHome's template text sensor with `update_interval: never` only publishes when explicitly triggered. Removing this allows the lambda to fire periodically as a fallback, ensuring the version is always reported.

Same fix as ApolloAutomation/AIR-1#87

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page