### PR TITLE
Fix: publish firmware version once on boot instead of polling

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -491,8 +491,7 @@ text_sensor:
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version
-    lambda: |-
-      return {"${version}"};
+    update_interval: never
     entity_category: "diagnostic"
   - platform: wifi_info
     ip_address:

--- a/Integrations/ESPHome/MTR-1.yaml
+++ b/Integrations/ESPHome/MTR-1.yaml
@@ -10,7 +10,12 @@ esphome:
 
   min_version: 2025.8.0
   on_boot:
-    priority: -10
+  - priority: 500
+    then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
+  - priority: -10
     then:
       - if:
           condition:

--- a/Integrations/ESPHome/MTR-1_BLE.yaml
+++ b/Integrations/ESPHome/MTR-1_BLE.yaml
@@ -10,7 +10,12 @@ esphome:
 
   min_version: 2025.8.0
   on_boot:
-    priority: -10
+  - priority: 500
+    then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
+  - priority: -10
     then:
       - if:
           condition:

--- a/Integrations/ESPHome/MTR-1_Factory.yaml
+++ b/Integrations/ESPHome/MTR-1_Factory.yaml
@@ -10,14 +10,19 @@ esphome:
 
   min_version: 2025.8.0
   on_boot:
-    priority: -10
+  - priority: 500
+    then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
+  - priority: -10
     then:
       - if:
           condition:
             - lambda: "return id(runTest);"
           then:
             - lambda: "id(testScript).execute();"
-  
+
 dashboard_import:
   package_import_url: github://ApolloAutomation/MTR-1/Integrations/ESPHome/MTR-1_Factory.yaml
   import_full_config: false


### PR DESCRIPTION
## Summary
- Replaced the 60s polling lambda with a single `text_sensor.template.publish` on boot
- Added `update_interval: never` back to the sensor definition since the value is a compile-time constant
- Consistent with the same fix applied across AIR-1, PLT-1, TEMP-1, BTN-1, PUMP-1, MSR-1, and MSR-2

Per ESPHome developer feedback: there's no need to poll a constant value every 60s — just publish it once at boot.