### PR TITLE
Release 26.3.2.1 - New sensors, ESPHome modernisation, and bug fixes

### DIFF
--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -7,12 +7,14 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+    # Skip auto-assign for pull requests from forks due to GITHUB_TOKEN permission restrictions
+    if: github.event_name == 'issues' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       issues: write
       pull-requests: write
     steps:
     - name: 'Auto-assign issue'
-      uses: pozil/auto-assign-issue@v1
+      uses: pozil/auto-assign-issue@v2
       with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: TrevorSchirmer

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -493,7 +493,6 @@ text_sensor:
     id: apollo_firmware_version
     lambda: |-
       return {"${version}"};
-    update_interval: never
     entity_category: "diagnostic"
   - platform: wifi_info
     ip_address:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -24,7 +24,7 @@ api:
         - rtttl.play:
             rtttl: !lambda "return song_str;"
 
-    #Co2 Calibration Service
+#Co2 Calibration Action
     - action: calibrate_co2_value
       variables:
         co2_ppm: float

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -80,6 +80,7 @@ uart:
     mode:
       input: true
       pullup: true
+  rx_buffer_size: 1024
   baud_rate: 256000
   parity: NONE
   stop_bits: 1

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -433,10 +433,11 @@ interval:
       - lambda: |-
           uint32_t current_time = millis() / 1000;  // Convert to seconds
           uint32_t last_update = id(ltr390_last_update);
-          uint32_t interval = (uint32_t)id(ltr390_update_interval).state;
+          float configured_interval = id(ltr390_update_interval).state;
+          uint32_t interval = (configured_interval >= 1.0f) ? (uint32_t)configured_interval : 60u;
 
           // Immediate update on boot (when last_update is still 0)
-          if (last_update == 0 && current_time > 0) {
+          if (last_update == 0) {
             id(ltr_390).update();
             id(ltr390_last_update) = current_time;
             return;

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -126,6 +126,21 @@ number:
       y2:
         name: Zone-3 Y2
   - platform: template
+    name: "DPS310 Pressure Offset"
+    id: dps310_pressure_offset
+    disabled_by_default: true
+    restore_value: true
+    initial_value: 0.0
+    min_value: -100.0
+    max_value: 100.0
+    entity_category: "CONFIG"
+    unit_of_measurement: "hPa"
+    optimistic: true
+    update_interval: never
+    step: 0.1
+    mode: box
+
+  - platform: template
     name: DPS310 Temperature Offset
     id: dps310_temperature_offset
     restore_value: true

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,18 +1,21 @@
 substitutions:
   name: apollo-mtr-1
-  version: "25.9.19.1"
+  version: "26.1.27.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
-  board: esp32-c3-devkitm-1
-  framework:
-    type: esp-idf
+  variant: esp32c3
+  flash_size: 4MB
 
 captive_portal:
 
+web_server:
+  port: 80
+  version: 3
+
 api:
-  services:
-    - service: play_buzzer
+  actions:
+    - action: play_buzzer
       variables:
         song_str: string
       then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-mtr-1
-  version: "26.1.27.1"
+  version: "26.2.2.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
@@ -62,6 +62,10 @@ globals:
     restore_value: no
     type: bool
     initial_value: "false"
+  - id: ltr390_last_update
+    restore_value: no
+    type: uint32_t
+    initial_value: '0'
 
 i2c:
   sda: GPIO1
@@ -161,6 +165,19 @@ number:
     step: 0.1
     mode: box
     disabled_by_default: true
+  - platform: template
+    name: LTR390 Update Interval
+    id: ltr390_update_interval
+    restore_value: true
+    initial_value: 60
+    min_value: 1
+    max_value: 300
+    entity_category: "CONFIG"
+    unit_of_measurement: "s"
+    optimistic: true
+    update_interval: never
+    step: 1
+    mode: box
 
 output:
   - platform: ledc
@@ -266,13 +283,13 @@ sensor:
 
   - platform: ltr390
     id: ltr_390
+    update_interval: never
     light:
       name: "LTR390 Light"
       id: ltr390light
     uv_index:
       name: "LTR390 UV Index"
       id: ltr390uvindex
-    update_interval: 5s
 
   - platform: ld2450
     ld2450_id: ld2450_radar
@@ -390,6 +407,19 @@ button:
           value: 420
           id: scd40
 
+interval:
+  - interval: 1s
+    then:
+      - lambda: |-
+          uint32_t current_time = millis() / 1000;  // Convert to seconds
+          uint32_t last_update = id(ltr390_last_update);
+          uint32_t interval = (uint32_t)id(ltr390_update_interval).state;
+
+          // Check if enough time has passed
+          if (current_time - last_update >= interval) {
+            id(ltr_390).update();
+            id(ltr390_last_update) = current_time;
+          }
 
 switch:
   - platform: factory_reset

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -6,6 +6,8 @@ substitutions:
 esp32:
   variant: esp32c3
   flash_size: 4MB
+  framework:
+    type: esp-idf
 
 captive_portal:
 

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -148,7 +148,7 @@ number:
     min_value: -70.0
     max_value: 70.0
     entity_category: "CONFIG"
-    unit_of_measurement: "°C"
+    unit_of_measurement: "Â°C"
     optimistic: true
     update_interval: never
     step: 0.1
@@ -161,7 +161,7 @@ number:
     min_value: -70.0
     max_value: 70.0
     entity_category: "CONFIG"
-    unit_of_measurement: "°C"
+    unit_of_measurement: "Â°C"
     optimistic: true
     update_interval: never
     step: 0.1

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -494,6 +494,11 @@ text_sensor:
       return {"${version}"};
     update_interval: never
     entity_category: "diagnostic"
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
+      id: wifi_ip
+      entity_category: "diagnostic"
 
 
 script:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -274,6 +274,10 @@ sensor:
     pressure:
       name: "DPS310 Pressure"
       id: dps310pressure
+      filters:
+        - lambda: |-
+            float offset = id(dps310_pressure_offset).state;
+            return isnan(offset) ? x : x + offset;
     temperature:
       name: "DPS310 Temperature"
       id: dps310temperature

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -464,6 +464,17 @@ text_sensor:
     target_3:
       direction:
         name: "Target-3 Direction"
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+    entity_category: "diagnostic"
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    lambda: |-
+      return {"${version}"};
+    update_interval: never
+    entity_category: "diagnostic"
 
 
 script:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -25,7 +25,7 @@ api:
             rtttl: !lambda "return song_str;"
 
     #Co2 Calibration Service
-    - service: calibrate_co2_value
+    - action: calibrate_co2_value
       variables:
         co2_ppm: float
       then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -491,8 +491,7 @@ text_sensor:
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version
-    lambda: |-
-      return {"${version}"};
+    update_interval: never
     entity_category: "diagnostic"
   - platform: wifi_info
     ip_address:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-mtr-1
-  version: "26.2.2.1"
+  version: "26.3.2.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
@@ -148,7 +148,7 @@ number:
     min_value: -70.0
     max_value: 70.0
     entity_category: "CONFIG"
-    unit_of_measurement: "Â°C"
+    unit_of_measurement: "°C"
     optimistic: true
     update_interval: never
     step: 0.1
@@ -161,7 +161,7 @@ number:
     min_value: -70.0
     max_value: 70.0
     entity_category: "CONFIG"
-    unit_of_measurement: "Â°C"
+    unit_of_measurement: "°C"
     optimistic: true
     update_interval: never
     step: 0.1

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -415,6 +415,13 @@ interval:
           uint32_t last_update = id(ltr390_last_update);
           uint32_t interval = (uint32_t)id(ltr390_update_interval).state;
 
+          // Immediate update on boot (when last_update is still 0)
+          if (last_update == 0 && current_time > 0) {
+            id(ltr_390).update();
+            id(ltr390_last_update) = current_time;
+            return;
+          }
+
           // Check if enough time has passed
           if (current_time - last_update >= interval) {
             id(ltr_390).update();

--- a/Integrations/ESPHome/MTR-1.yaml
+++ b/Integrations/ESPHome/MTR-1.yaml
@@ -10,7 +10,12 @@ esphome:
 
   min_version: 2025.8.0
   on_boot:
-    priority: -10
+  - priority: 500
+    then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
+  - priority: -10
     then:
       - if:
           condition:

--- a/Integrations/ESPHome/MTR-1.yaml
+++ b/Integrations/ESPHome/MTR-1.yaml
@@ -3,14 +3,12 @@ esphome:
   friendly_name: Apollo MTR-1
   comment: Apollo MTR-1
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
 
   project:
     name: "ApolloAutomation.MTR-1"
     version: "${version}"
 
-  min_version: 2024.6.0
+  min_version: 2025.8.0
   on_boot:
     priority: -10
     then:
@@ -35,8 +33,5 @@ wifi:
   ap:
     ssid: "Apollo MTR1 Hotspot"
     
-web_server:
-  port: 80
-
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/MTR-1_BLE.yaml
+++ b/Integrations/ESPHome/MTR-1_BLE.yaml
@@ -3,14 +3,12 @@ esphome:
   friendly_name: Apollo MTR-1
   comment: Apollo MTR-1
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
 
   project:
     name: "ApolloAutomation.MTR-1"
     version: "${version}"
 
-  min_version: 2024.6.4
+  min_version: 2025.8.0
   on_boot:
     priority: -10
     then:

--- a/Integrations/ESPHome/MTR-1_BLE.yaml
+++ b/Integrations/ESPHome/MTR-1_BLE.yaml
@@ -10,7 +10,12 @@ esphome:
 
   min_version: 2025.8.0
   on_boot:
-    priority: -10
+  - priority: 500
+    then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
+  - priority: -10
     then:
       - if:
           condition:

--- a/Integrations/ESPHome/MTR-1_Factory.yaml
+++ b/Integrations/ESPHome/MTR-1_Factory.yaml
@@ -28,11 +28,6 @@ esp32_improv:
   authorizer: none
 
 wifi:
-  on_connect:
-    - delay: 5s  
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
   ap:
     ssid: "Apollo MTR1 Hotspot"
 

--- a/Integrations/ESPHome/MTR-1_Factory.yaml
+++ b/Integrations/ESPHome/MTR-1_Factory.yaml
@@ -10,14 +10,19 @@ esphome:
 
   min_version: 2025.8.0
   on_boot:
-    priority: -10
+  - priority: 500
+    then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
+  - priority: -10
     then:
       - if:
           condition:
             - lambda: "return id(runTest);"
           then:
             - lambda: "id(testScript).execute();"
-  
+
 dashboard_import:
   package_import_url: github://ApolloAutomation/MTR-1/Integrations/ESPHome/MTR-1_Factory.yaml
   import_full_config: false


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.3.2.1

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

Merges beta into main for the 26.3.2.1 release. Changes include:

- **ESPHome 2026 modernisation** — web server v3, explicit `esp-idf` framework to silence ESPHome 2026.1.0 warning, `play_buzzer` service renamed to action *(breaking: existing HA automations calling the buzzer service will need updating)*
- **API service → action rename** — CO2 calibration renamed from `service` to `action` *(breaking: existing HA automations will need updating)*
- **Removed BLE disabling logic** — ESPHome devs confirmed it's unnecessary; makes manual BLE proxy YAML easier to add
- **Configurable LTR390 update interval** — adjustable 1–300s via web interface, persisted across reboots
- **Fix LD2450 buffer overflow** — UART `rx_buffer_size` increased 256→1024 bytes to prevent corruption during boot initialization (~750 bytes sent by LD2450 on startup)
- **Configurable DPS310 pressure offset** — NaN-guarded filter lambda, disabled by default
- **IP address text sensor** — via `wifi_info` platform
- **ESPHome version + Apollo firmware version text sensors**
- **Fix auto-assign workflow** — upgraded to `pozil/auto-assign-issue@v2`, skips forked PRs to prevent 403 errors
- **Bug fixes** — LTR390 interval NaN handling, Apollo firmware version showing "unknown", UTF-8 special character restoration

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [x] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [x] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic entities for system information (version, IP address, firmware version).
  * Enabled dynamic sensor polling with user-configurable update intervals.
  * Added web server interface support.

* **Chores**
  * Updated firmware version to 26.3.2.1.
  * Updated ESPHome minimum version requirements.
  * Converted API model from services to actions.
  * Improved pull request automation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->