### PR TITLE
Filter LD2450 NaN to 0 when no target detected

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -323,42 +323,78 @@ sensor:
     target_1:
       x:
         name: Target-1 X
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
       y:
         name: Target-1 Y
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
       speed:
         name: Target-1 Speed
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
       angle:
         name: Target-1 Angle
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
       distance:
         name: Target-1 Distance
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
       resolution:
         name: Target-1 Resolution
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
     target_2:
       x:
         name: Target-2 X
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
       y:
         name: Target-2 Y
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
       speed:
         name: Target-2 Speed
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
       angle:
         name: Target-2 Angle
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
       distance:
         name: Target-2 Distance
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
       resolution:
         name: Target-2 Resolution
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
     target_3:
       x:
         name: Target-3 X
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
       y:
         name: Target-3 Y
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
       speed:
         name: Target-3 Speed
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
       angle:
         name: Target-3 Angle
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
       distance:
         name: Target-3 Distance
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
       resolution:
         name: Target-3 Resolution
+        filters:
+          - lambda: return isnan(x) ? 0.0 : x;
     zone_1:
       target_count:
         name: Zone-1 All Target Count

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -324,77 +324,95 @@ sensor:
       x:
         name: Target-1 X
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
       y:
         name: Target-1 Y
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
       speed:
         name: Target-1 Speed
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
       angle:
         name: Target-1 Angle
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
       distance:
         name: Target-1 Distance
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
       resolution:
         name: Target-1 Resolution
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
     target_2:
       x:
         name: Target-2 X
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
       y:
         name: Target-2 Y
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
       speed:
         name: Target-2 Speed
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
       angle:
         name: Target-2 Angle
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
       distance:
         name: Target-2 Distance
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
       resolution:
         name: Target-2 Resolution
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
     target_3:
       x:
         name: Target-3 X
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
       y:
         name: Target-3 Y
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
       speed:
         name: Target-3 Speed
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
       angle:
         name: Target-3 Angle
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
       distance:
         name: Target-3 Distance
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
       resolution:
         name: Target-3 Resolution
         filters:
-          - lambda: return isnan(x) ? 0.0 : x;
+          - lambda: |-
+              return isnan(x) ? 0.0 : x;
     zone_1:
       target_count:
         name: Zone-1 All Target Count


### PR DESCRIPTION
Version: 26.3.2.2

## What does this implement/fix?

Restores the pre-2026.3 behavior of the LD2450 per-target numeric sensors so they report \`0\` instead of \`unknown\` when a target slot is empty.

### Background

ESPHome PR https://github.com/esphome/esphome/pull/13602 changed the \`ld2450\` component to publish \`NaN\` for \`x\`, \`y\`, \`speed\`, \`angle\`, \`distance\`, and \`resolution\` when no target is present in a given slot. Home Assistant renders \`NaN\` as \`unknown\`, which breaks numeric_state triggers, history graphs, and statistics built around these entities.

The change was intentional upstream, intended to disambiguate "no target" from coordinate (0, 0). However, in Home Assistant the resulting \`unknown\` state breaks numeric_state triggers, history graphs, and statistics built on these entities. This PR restores the prior numeric behavior for Apollo users until upstream provides a non-breaking opt-in.

Closes #89.

### Change

Adds a single-line lambda filter (\`isnan(x) ? 0.0 : x\`) to all 18 per-target numeric sensors (target_1/2/3 x x/y/speed/angle/distance/resolution).

The \`direction\` text_sensor (already shows "NA"), target/zone counts, and binary sensors are unaffected.

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish

## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page