### PR TITLE
Add managed firmware update system

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,6 +2,7 @@ name-template: 'Release v$NEXT_PATCH_VERSION'
 tag-template: "$RESOLVED_VERSION"
 change-template: "- #$NUMBER $TITLE @$AUTHOR"
 sort-direction: ascending
+category-template: '**$TITLE**'
 
 categories:
   - title: "🚨 Breaking changes"
@@ -41,11 +42,9 @@ include-labels:
 
 no-changes-template: '- No changes'
 
+# The shared build workflow appends a Full Changelog compare link to the
+# release body (release-drafter cannot render 4-part version tags).
 template: |
-  ## What's Changed
+  **What's Changed**
 
   $CHANGES
-
-  **Full Changelog**: https://github.com/ApolloAutomation/MTR-1/compare/$PREVIOUS_TAG...$RESOLVED_VERSION.1
-
-   Be sure to 🌟 this repository for updates!

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,8 @@ jobs:
       device-name: mtr-1
       yaml-files: |
         Integrations/ESPHome/MTR-1_Factory.yaml
-      firmware-names: "1_Factory:firmware"
+        Integrations/ESPHome/MTR-1_BLE.yaml
+      firmware-names: "1_Factory:firmware,1_BLE:firmware-ble"
       core-yaml-path: Integrations/ESPHome/Core.yaml
       esphome-version: stable
       # Bypass check if manually triggered with bypass option

--- a/Integrations/ESPHome/MTR-1.yaml
+++ b/Integrations/ESPHome/MTR-1.yaml
@@ -8,7 +8,7 @@ esphome:
     name: "ApolloAutomation.MTR-1"
     version: "${version}"
 
-  min_version: 2025.8.0
+  min_version: 2025.11.0
   on_boot:
   - priority: 500
     then:

--- a/Integrations/ESPHome/MTR-1.yaml
+++ b/Integrations/ESPHome/MTR-1.yaml
@@ -48,6 +48,8 @@ update:
 
 wifi:
   power_save_mode: none
+  on_connect:
+    - component.update: update_http_request
   ap:
     ssid: "Apollo MTR1 Hotspot"
     

--- a/Integrations/ESPHome/MTR-1.yaml
+++ b/Integrations/ESPHome/MTR-1.yaml
@@ -32,6 +32,19 @@ dashboard_import:
 ota:
   - platform: esphome
     id: ota_default
+  - platform: http_request
+    id: ota_managed
+
+http_request:
+  verify_ssl: true
+
+safe_mode:
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: https://apolloautomation.github.io/MTR-1/firmware/manifest.json
 
 wifi:
   power_save_mode: none

--- a/Integrations/ESPHome/MTR-1_BLE.yaml
+++ b/Integrations/ESPHome/MTR-1_BLE.yaml
@@ -8,7 +8,7 @@ esphome:
     name: "ApolloAutomation.MTR-1"
     version: "${version}"
 
-  min_version: 2025.8.0
+  min_version: 2025.11.0
   on_boot:
   - priority: 500
     then:

--- a/Integrations/ESPHome/MTR-1_BLE.yaml
+++ b/Integrations/ESPHome/MTR-1_BLE.yaml
@@ -32,6 +32,19 @@ dashboard_import:
 ota:
   - platform: esphome
     id: ota_esphome
+  - platform: http_request
+    id: ota_managed
+
+http_request:
+  verify_ssl: true
+
+safe_mode:
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: https://apolloautomation.github.io/MTR-1/firmware-ble/manifest.json
 
 wifi:
   ap:

--- a/Integrations/ESPHome/MTR-1_BLE.yaml
+++ b/Integrations/ESPHome/MTR-1_BLE.yaml
@@ -47,6 +47,8 @@ update:
     source: https://apolloautomation.github.io/MTR-1/firmware-ble/manifest.json
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   ap:
     ssid: "Apollo MTR1 Hotspot"
 

--- a/Integrations/ESPHome/MTR-1_Factory.yaml
+++ b/Integrations/ESPHome/MTR-1_Factory.yaml
@@ -33,6 +33,8 @@ esp32_improv:
   authorizer: none
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   ap:
     ssid: "Apollo MTR1 Hotspot"
 

--- a/Integrations/ESPHome/MTR-1_Factory.yaml
+++ b/Integrations/ESPHome/MTR-1_Factory.yaml
@@ -8,7 +8,7 @@ esphome:
     name: "ApolloAutomation.MTR-1"
     version: "${version}"
 
-  min_version: 2025.8.0
+  min_version: 2025.11.0
   on_boot:
   - priority: 500
     then:

--- a/Integrations/ESPHome/MTR-1_Factory.yaml
+++ b/Integrations/ESPHome/MTR-1_Factory.yaml
@@ -41,7 +41,19 @@ logger:
 ota:
   - platform: esphome
     id: ota_esphome
+  - platform: http_request
+    id: ota_managed
 
+http_request:
+  verify_ssl: true
+
+safe_mode:
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: https://apolloautomation.github.io/MTR-1/firmware/manifest.json
 
 packages:
   core: !include Core.yaml


### PR DESCRIPTION
Ports the managed OTA update system from R_PRO-1 to all MTR-1 variants, so devices can self-update from the GitHub Pages manifests directly in Home Assistant.

## Changes

- `update: http_request` component (Firmware Update entity in HA) + `ota: http_request` platform on all three variants, pulling from the existing GitHub Pages manifests
- `safe_mode` for boot-loop recovery after a bad flash
- `http_request` with `verify_ssl: true` (esp-idf TLS, same as R_PRO-1)
- BLE variant is now built and published by CI to its own `firmware-ble/` manifest, and `MTR-1_BLE.yaml` updates from it — without this, a BLE device taking an update would be silently converted to the factory (non-BLE) firmware and lose Bluetooth proxy
- Manifest check triggered on `wifi.on_connect`: the update component's first 6-hour poll fires before the network is up and skips silently, leaving the entity stale for ~6h after every boot (R_PRO-1 has this today). The trigger makes the entity accurate within seconds of boot.
- `min_version` raised to 2025.11.0 to match the floor R_PRO-1 set when this system landed there

## Testing

Tested end to end on a physical MTR-1 (both the factory-path and BLE-path manifests): flash → update offered in HA with release notes → OTA install from Pages → reboot on new version → Bluetooth proxy intact on the BLE variant. Verified across seven consecutive mock releases on a fork.

Note for support: devices need outbound HTTPS (443) to `apolloautomation.github.io` — isolated IoT VLANs that block egress will show "up to date" forever with `ESP_ERR_HTTP_CONNECT` in debug logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a BLE firmware variant alongside the factory firmware.
  * Devices now use an HTTP-based firmware update flow that checks for updates automatically on Wi‑Fi connect.

* **Chores**
  * Bumped minimum ESPHome requirement to 2025.11.0.
  * CI/release workflow updated to build/publish the additional BLE firmware and adjusted release formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->