### PR TITLE
Consolidate workflows into shared ApolloAutomation/Workflows reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,15 @@
-# To get started with Dependabot version updates, you'll need to specify which
- # package ecosystems to update and where the package manifests are located.
- # Please see the documentation for all configuration options:
- # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
- version: 2
- updates:
-   - package-ecosystem: "github-actions"
-     directory: "/"
-     schedule:
-       interval: "daily"
-     commit-message:
-       prefix: "chore(ci): "
-     groups:
-       github-actions:
-         patterns:
-           - "*"
+# Action version pins live in ApolloAutomation/Workflows (reusable workflows
+# referenced @main), so this config normally has nothing to update. It stays
+# as a safety net in case a version-pinned action is added here later.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(ci): "
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -1,21 +1,20 @@
 name: Auto Assign
+
 on:
   issues:
     types: [opened]
   pull_request:
     types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
-  run:
-    runs-on: ubuntu-latest
+  auto-assign:
     # Skip auto-assign for pull requests from forks due to GITHUB_TOKEN permission restrictions
     if: github.event_name == 'issues' || github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      issues: write
-      pull-requests: write
-    steps:
-    - name: 'Auto-assign issue'
-      uses: pozil/auto-assign-issue@v3
-      with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          assignees: bharvey88
-          numOfAssignee: 1
+    uses: ApolloAutomation/Workflows/.github/workflows/autoassign.yml@main
+    with:
+      assignees: bharvey88
+      num-of-assignees: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,34 +4,21 @@ on:
   pull_request:
 
 permissions:
-  # Allow GITHUB_TOKEN to add labels to pull requests
   pull-requests: write
   issues: write
   contents: read
-  id-token: write
 
 jobs:
   label-check:
     name: Label Check
     uses: ApolloAutomation/Workflows/.github/workflows/label-check.yml@main
-    
+
   ci:
-    name: Building ${{ matrix.file }} / ESPHome ${{ matrix.esphome-version }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        file:
-          - Integrations/ESPHome/MTR-1_Factory.yaml
-          - Integrations/ESPHome/MTR-1.yaml
-          - Integrations/ESPHome/MTR-1_BLE.yaml
-        esphome-version:
-          - stable
-          - beta
-          - dev
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v6.0.2
-      - name: Build ESPHome firmware to verify configuration
-        uses: esphome/build-action@v7
-        with:
-          yaml-file: ${{ matrix.file }}
+    name: CI
+    uses: ApolloAutomation/Workflows/.github/workflows/esphome-ci.yml@main
+    with:
+      yaml-files: |
+        Integrations/ESPHome/MTR-1_Factory.yaml
+        Integrations/ESPHome/MTR-1.yaml
+        Integrations/ESPHome/MTR-1_BLE.yaml
+

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -4,24 +4,16 @@ on:
   schedule:
     - cron: '0 0 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   build:
-    name: Building ${{ matrix.file }} / ESPHome ${{ matrix.esphome-version }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        file:
-          - Integrations/ESPHome/MTR-1_Factory.yaml
-          - Integrations/ESPHome/MTR-1.yaml
-          - Integrations/ESPHome/MTR-1_BLE.yaml
-        esphome-version:
-          - stable
-          - beta
-          - dev
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v6.0.2
-      - name: Build ESPHome firmware to verify configuration
-        uses: esphome/build-action@v7
-        with:
-          yaml-file: ${{ matrix.file }}
+    name: Weekly Build
+    uses: ApolloAutomation/Workflows/.github/workflows/esphome-ci.yml@main
+    with:
+      yaml-files: |
+        Integrations/ESPHome/MTR-1_Factory.yaml
+        Integrations/ESPHome/MTR-1.yaml
+        Integrations/ESPHome/MTR-1_BLE.yaml
+


### PR DESCRIPTION
Version:

## What does this implement/fix?

Consolidates this repo's CI, weekly build, and auto-assign workflows into thin callers of the shared [ApolloAutomation/Workflows](https://github.com/ApolloAutomation/Workflows) reusable workflows (`esphome-ci.yml`, `autoassign.yml`), the same pattern `build.yml` already uses. The repo now contains **zero version-pinned actions**, so Dependabot has nothing to bump here — action updates land as a single grouped PR in the Workflows repo and propagate to the whole fleet via `@main`. The local dependabot schedule is relaxed to monthly as a safety net.

Also fixes a latent CI bug: the old inline matrix listed ESPHome stable/beta/dev but never passed the version to `esphome/build-action`, so all three legs built the same default version. The shared workflow passes `version:` through, so the matrix now genuinely tests all three channels.

This PR validates itself: the checks below run the new thin `ci.yml` → shared `esphome-ci.yml` matrix.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [x] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
