### PR TITLE
Update Firmware Select

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -41,8 +41,8 @@ jobs:
         include:
           # Beta serves OTA updates only, so it builds the end-user image
           # (MTR-1.yaml), not the first-flash Factory image.
-          - { yaml: Integrations/ESPHome/beta-channel/MTR-1.yaml,     name: firmware-standard }
-          - { yaml: Integrations/ESPHome/beta-channel/MTR-1_BLE.yaml, name: firmware-ble-beta }
+          - { yaml: Integrations/ESPHome/MTR-1.yaml,     name: firmware-standard }
+          - { yaml: Integrations/ESPHome/MTR-1_BLE.yaml, name: firmware-ble-beta }
     uses: esphome/workflows/.github/workflows/build.yml@025a1e6255610c498ed590403b7e510b69e474df # 2026.4.1
     with:
       files: ${{ matrix.yaml }}

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,12 +1,7 @@
 substitutions:
   name: apollo-mtr-1
-  version: "26.8.18.1"
+  version: "26.8.18.2"
   device_description: ${name} made by Apollo Automation - version ${version}.
-  # Default update channel on first boot (no stored user choice yet, i.e. a
-  # fresh flash). The beta-channel builds override this to "Beta" (see
-  # Integrations/ESPHome/beta-channel/) so firmware obtained from the beta
-  # channel keeps tracking it instead of offering a stable "downgrade".
-  firmware_channel_default: "Stable"
   # Manifest URL bases. Stable = GitHub Pages (main branch builds).
   # Beta = rolling "beta-fw" pre-release assets (beta branch builds).
   stable_manifest_base: "https://apolloautomation.github.io/MTR-1"
@@ -637,7 +632,7 @@ select:
     options:
       - "Stable"
       - "Beta"
-    initial_option: "${firmware_channel_default}"
+    initial_option: "Stable"
     on_value:
       then:
         - script.execute: apply_ota_source

--- a/Integrations/ESPHome/beta-channel/MTR-1.yaml
+++ b/Integrations/ESPHome/beta-channel/MTR-1.yaml
@@ -1,9 +1,0 @@
-# Beta-channel build of MTR-1.yaml: the identical image except the Firmware
-# Channel select defaults to "Beta" on first boot, so firmware obtained from
-# the beta channel keeps tracking it. Built by build-beta.yml only; the
-# stable (GitHub Pages) builds use MTR-1.yaml directly.
-substitutions:
-  firmware_channel_default: "Beta"
-
-packages:
-  base: !include ../MTR-1.yaml

--- a/Integrations/ESPHome/beta-channel/MTR-1_BLE.yaml
+++ b/Integrations/ESPHome/beta-channel/MTR-1_BLE.yaml
@@ -1,9 +1,0 @@
-# Beta-channel build of MTR-1_BLE.yaml: the identical image except the Firmware
-# Channel select defaults to "Beta" on first boot, so firmware obtained from
-# the beta channel keeps tracking it. Built by build-beta.yml only; the
-# stable (GitHub Pages) builds use MTR-1_BLE.yaml directly.
-substitutions:
-  firmware_channel_default: "Beta"
-
-packages:
-  base: !include ../MTR-1_BLE.yaml


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.8.18.2

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

- Remove the beta-channel folder; beta builds now use the plain variant configs and the Firmware Channel select defaults to Stable on all builds. Mirrors CAST-1 #60.
- `esphome config` validates MTR-1.yaml, MTR-1_BLE.yaml, and MTR-1_Factory.yaml (ESPHome 2026.7.4).

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated firmware to version 26.8.18.2.
  * Firmware channel selection now defaults to Stable.

* **Bug Fixes**
  * Beta builds now use the primary MTR-1 and MTR-1 BLE configurations, ensuring they build from the current integration definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->